### PR TITLE
3/media query debugger

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,13 @@
 module.exports = {
   env: {
-    browser: true
+    browser: true,
+    jest: true
   },
   extends: ["eslint:recommended", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
   globals: {
     __PATH_PREFIX__: true
   },
-  plugins: ["prettier", "jsx-a11y"],
+  plugins: ["prettier", "jsx-a11y", "jest"],
   parser: "babel-eslint",
   parserOptions: {
     ecmaFeatures: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,12 @@
 module.exports = {
   env: {
-    browser: true,
-    jest: true
+    browser: true
   },
   extends: ["eslint:recommended", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
   globals: {
     __PATH_PREFIX__: true
   },
-  plugins: ["prettier", "jsx-a11y", "jest"],
+  plugins: ["prettier", "jsx-a11y"],
   parser: "babel-eslint",
   parserOptions: {
     ecmaFeatures: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    plugins: [`gatsby-plugin-sass`]
+  }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-import Link from "./src/components/link"
-
-export { Link }
+import MediaQueryDebugger from './src/components/MediaQuerryDebugger/index'
+export {MediaQueryDebugger}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "docz": "latest",
     "gatsby": "^2.19.12",
+    "gatsby-plugin-sass": "^2.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "sass": "^1.26.3"
   },
   "devDependencies": {
     "babel-jest": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:update": "jest src --updateSnapshot"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "docz": "latest",
     "gatsby": "^2.19.12",
     "gatsby-plugin-sass": "^2.2.1",

--- a/src/components/MediaQuerryDebugger/__snapshots__/test.spec.js.snap
+++ b/src/components/MediaQuerryDebugger/__snapshots__/test.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaQueryDebugger renders correctly 1`] = `null`;

--- a/src/components/MediaQuerryDebugger/__snapshots__/test.spec.js.snap
+++ b/src/components/MediaQuerryDebugger/__snapshots__/test.spec.js.snap
@@ -1,3 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MediaQueryDebugger renders correctly 1`] = `null`;
+exports[`MediaQueryDebugger renders correctly 1`] = `
+<div
+  className="debug"
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex={0}
+>
+  <div
+    className="debug_media_queries"
+  />
+</div>
+`;

--- a/src/components/MediaQuerryDebugger/index.js
+++ b/src/components/MediaQuerryDebugger/index.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react'
 import classNames from 'classnames/bind'
+import propTypes from 'prop-types'
 import styles from './styles.module.scss'
 
-const MediaQueryDebugger = () => {
-  if (process.env.GATSBY_DEBUG_MEDIA_QUERIES !== 'true') return null
+const MediaQueryDebugger = ( props ) => {
+  
+  if (props.isVisible != 'true') return null
 
   const [isOpen, setOpen] = useState(false)
 
@@ -12,10 +14,15 @@ const MediaQueryDebugger = () => {
   })
 
   return (
-    <div className={classes} onClick={() => {setOpen(!isOpen)}}>
+    <div role="button" className={classes} tabIndex={0} onKeyDown={() => {setOpen(!isOpen)}} >
       <div className={styles.debug_media_queries} />
     </div>
   )
+}
+
+MediaQueryDebugger.propTypes = {
+  // a string determines whether or not the component should be visible
+  isVisible: propTypes.string
 }
 
 export default MediaQueryDebugger

--- a/src/components/MediaQuerryDebugger/index.js
+++ b/src/components/MediaQuerryDebugger/index.js
@@ -11,9 +11,6 @@ const MediaQueryDebugger = () => {
     [styles.is_showing]: isOpen
   })
 
-  console.log(styles);
-  
-
   return (
     <div className={classes} onClick={() => {setOpen(!isOpen)}}>
       <div className={styles.debug_media_queries} />

--- a/src/components/MediaQuerryDebugger/index.js
+++ b/src/components/MediaQuerryDebugger/index.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import classNames from 'classnames/bind'
+import styles from './styles.module.scss'
+
+const MediaQueryDebugger = () => {
+  if (process.env.GATSBY_DEBUG_MEDIA_QUERIES !== 'true') return null
+
+  const [isOpen, setOpen] = useState(false)
+
+  const classes = classNames(styles.debug, isOpen, {
+    [styles.is_showing]: isOpen
+  })
+
+  console.log(styles);
+  
+
+  return (
+    <div className={classes} onClick={() => {setOpen(!isOpen)}}>
+      <div className={styles.debug_media_queries} />
+    </div>
+  )
+}
+
+export default MediaQueryDebugger

--- a/src/components/MediaQuerryDebugger/notes.mdx
+++ b/src/components/MediaQuerryDebugger/notes.mdx
@@ -1,0 +1,20 @@
+---
+name: Media Query Debugger
+menu: Components
+route: /components/media-debugger
+---
+
+import { Playground, Props } from "docz"
+import MediaQueryDebugger from "./"
+
+# Media Query Debugger
+
+This component provides a quick way to find the current media query for faster local development.
+
+## Usage
+
+```
+yarn run develop:debug
+```
+
+_The media query degugger is located in the bottom left of the browser durning local development_

--- a/src/components/MediaQuerryDebugger/notes.mdx
+++ b/src/components/MediaQuerryDebugger/notes.mdx
@@ -1,7 +1,7 @@
 ---
 name: Media Query Debugger
 menu: Components
-route: /components/media-debugger
+route: /components/MediaQueryDebugger
 ---
 
 import { Playground, Props } from "docz"
@@ -10,6 +10,7 @@ import MediaQueryDebugger from "./"
 # Media Query Debugger
 
 This component provides a quick way to find the current media query for faster local development.
+_The media query degugger is located in the bottom left of the browser durning local development_
 
 ## Usage
 
@@ -17,4 +18,6 @@ This component provides a quick way to find the current media query for faster l
 yarn run develop:debug
 ```
 
-_The media query degugger is located in the bottom left of the browser durning local development_
+## Properties
+
+<Props of={MediaQueryDebugger} />

--- a/src/components/MediaQuerryDebugger/styles.module.scss
+++ b/src/components/MediaQuerryDebugger/styles.module.scss
@@ -1,0 +1,76 @@
+$media-queries: (
+  smallest: 0,
+  x-small-lowest: 360px,
+  x-small: 400px,
+  x-small-highest: 480px,
+  small-lowest: 600px,
+  small: 720px,
+  small-highest: 840px,
+  medium-lowest: 960px,
+  medium: 1040px,
+  large-lowest: 1280px,
+  large: 1440px,
+  large-highest: 1600px,
+  x-large-lowest: 1920px,
+  x-large: 2560px,
+  x-large-highest: 3360px
+);
+
+// ---------------------------------------------------------
+
+$background-color: rgba(0, 0, 0, 0.8);
+$content-color: #ded;
+$size: 44px;
+
+// ---------------------------------------------------------
+
+.debug {
+  align-items: center;
+  background-color: $background-color;
+  bottom: 0;
+  display: flex;
+  font-family: system-ui;
+  height: $size;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  text-align: center;
+  transition: width 0.3s ease-in-out;
+  width: 0;
+  z-index: 4;
+
+  &:after {
+    background-color: transparent;
+    border-color: transparent transparent transparent $background-color;
+    border-style: solid;
+    border-width: $size 0 0 $size;
+    content: '';
+    display: block;
+    position: absolute;
+    right: -$size;
+  }
+
+  &.is_showing {
+    width: 100vw;
+  }
+}
+
+.debug_media_queries {
+  font-size: 0;
+  opacity: 0;
+  transition: opacity 0.5s 0.1s ease-in-out;
+
+  .is_showing & {
+    color: $content-color;
+    font-size: 12px;
+    opacity: 1;
+  }
+
+  @each $mq in $media-queries {
+    @media screen and (min-width: nth($mq, 2)) {
+      &::after {
+        content: '#{nth($mq, 1)} - min-width: #{nth($mq, 2)}';
+      }
+    }
+  }
+}

--- a/src/components/MediaQuerryDebugger/test.spec.js
+++ b/src/components/MediaQuerryDebugger/test.spec.js
@@ -4,7 +4,7 @@ import MediaQueryDebugger from "./index"
 
 describe("MediaQueryDebugger", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<MediaQueryDebugger isVisible={true}/>).toJSON()
+    const tree = renderer.create(<MediaQueryDebugger isVisible={'true'}/>).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/MediaQuerryDebugger/test.spec.js
+++ b/src/components/MediaQuerryDebugger/test.spec.js
@@ -1,0 +1,10 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import MediaQueryDebugger from "./index"
+
+describe("MediaQueryDebugger", () => {
+  it("renders correctly", () => {
+    const tree = renderer.create(<MediaQueryDebugger isVisible={true}/>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,6 +907,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.7":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.4.5":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.8.4.tgz#c50ed8a93c12141e638ea87ca4cdf6b4665a0bac"
@@ -3214,6 +3221,21 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.0.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -3232,21 +3254,6 @@ chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.0.2:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 chownr@^1.1.1, chownr@^1.1.3:
   version "1.1.3"
@@ -3381,6 +3388,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
 
 clone-response@1.0.2, clone-response@^1.0.2:
   version "1.0.2"
@@ -4780,6 +4796,11 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 emotion-theming@^10.0.14:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.27.tgz#1887baaec15199862c89b1b984b79806f2b9ab10"
@@ -6009,6 +6030,14 @@ gatsby-plugin-root-import@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-root-import/-/gatsby-plugin-root-import-2.0.5.tgz#04e520dc661d67f49aa7950f11b7c780fd2fdbd3"
   integrity sha512-/yA6rFjfjiFb8D6nCjfFrrGqYQMkOt4J3u2o6s7VYEF/zpA5dw2C9ENJ5fDKkJSCbbwLiEIGVMMee3vMEip2zA==
+
+gatsby-plugin-sass@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-2.2.1.tgz#574d2ff4763e5a78648d69022b7b570da9f903cb"
+  integrity sha512-YRzP5ZrGgABF/3ya9YJz80+pqLpVVuJf8gyBFjvC+GmM8kqbwm5w9k3HOf61kYcCDg5bje1CPNXu7ZQMkxu2mQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    sass-loader "^7.3.1"
 
 gatsby-plugin-typescript@^2.1.6:
   version "2.1.27"
@@ -8550,6 +8579,15 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-utils@^1.0.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
 
 loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
@@ -11501,6 +11539,11 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
 regenerator-transform@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
@@ -12131,6 +12174,24 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sass-loader@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
+  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+  dependencies:
+    clone-deep "^4.0.1"
+    loader-utils "^1.0.1"
+    neo-async "^2.5.0"
+    pify "^4.0.1"
+    semver "^6.3.0"
+
+sass@^1.26.3:
+  version "1.26.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.3.tgz#412df54486143b76b5a65cdf7569e86f44659f46"
+  integrity sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -12323,6 +12384,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 shallow-compare@^1.2.2:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,6 +3290,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@4.2.x:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"


### PR DESCRIPTION
Closes #3 

### Notes

When locally linking this component to GIAC using `yarn link` I ran into the following 3 issues ... 

1. Running `$ yarn link gatsby-theme-ample-components` in your target repository after running `$ yarn link` creates a symbolic link in `node_modules` that overwrites the `gatsby-theme-ample-components` theme directory in `node_modules`, causing webpack to fail it's SSR bundle generator.  One solution to this is to change the name of your link in `package.json`

2. Running `$ yarn develop` will cause webpack to throw a missing module error in `.eslint.rc.js` for `eslint-plugin-jest`. I was able to work around this by removing jest in `.eslint.rc.js` 

3. After bypassing the previous issue for `$ yarn develop` I ran into another link issue ... `Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons`. The solution for this can be found [here](https://github.com/facebook/react/issues/15315#issuecomment-479802153)

